### PR TITLE
rspec closure updates for working tests

### DIFF
--- a/spec/student_spec.rb
+++ b/spec/student_spec.rb
@@ -96,7 +96,7 @@ describe Student do
         all_from_db = Student.all 
         expect(all_from_db.size).to eq(2)
         expect(all_from_db.last).to be_an_instance_of(Student)
-        expect(all_from_db.any? {|student| student.name == "Sam"}.to eq(true)         
+        expect(all_from_db.any? {|student| student.name == "Sam"}.to eq(true))        
       end
     end
   end
@@ -151,4 +151,5 @@ describe Student do
         expect(all_in_9.size).to eq(1)
       end
     end
-end
+  end
+


### PR DESCRIPTION
I opened the lab, and right off the bat the tests were throwing errors:

```// ♥ rspec spec/student_spec.rb 
/Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/configuration.rb:1361:in `load': /Users/Roberto/Development/code/orm-mapping-db-to-ruby-object-lab-v-000/spec/student_spec.rb:100: syntax error, unexpected keyword_end, expecting ')' (SyntaxError)
/Users/Roberto/Development/code/orm-mapping-db-to-ruby-object-lab-v-000/spec/student_spec.rb:154: syntax error, unexpected end-of-input, expecting keyword_end
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/configuration.rb:1361:in `block in load_spec_files'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/configuration.rb:1359:in `each'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/configuration.rb:1359:in `load_spec_files'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/runner.rb:102:in `setup'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/runner.rb:88:in `run'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/runner.rb:73:in `run'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/lib/rspec/core/runner.rb:41:in `invoke'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/gems/rspec-core-3.4.1/exe/rspec:4:in `<top (required)>'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/bin/rspec:23:in `load'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/bin/rspec:23:in `<main>'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `eval'
	from /Users/Roberto/.rvm/gems/ruby-2.2.3/bin/ruby_executable_hooks:15:in `<main>'
```

These two fixes, get the tests running. I hope this helps!